### PR TITLE
Repair deployment from Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ deploy:
   file_glob: true
   file: bundle.tar.gz
   on:
-    repo: Artsdatabanken/nin-innsyn
+    repo: Artsdatabanken/nin-kart-frontend
   skip_cleanup: true
 after_deploy: ./slack.sh ops "deploy nin-innsyn"
 after_success:


### PR DESCRIPTION
Error: Skipping a deployment with the releases provider because this repo's name does not match one specified in .[secure].yml's deploy.on.repo: [secure]en/nin-innsyn