### PR TITLE
Gjort det vesentlig lettere for brukere som benytter tab til navigering å bruke siden

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3602,22 +3602,6 @@
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
       "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
     },
-    "axios": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.18.0.tgz",
-      "integrity": "sha1-MtU+SFHv3AoRmTts0AB4nXDAUQI=",
-      "requires": {
-        "follow-redirects": "^1.3.0",
-        "is-buffer": "^1.1.5"
-      },
-      "dependencies": {
-        "is-buffer": {
-          "version": "1.1.6",
-          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-          "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
-        }
-      }
-    },
     "axobject-query": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.0.2.tgz",
@@ -9945,8 +9929,7 @@
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -9983,8 +9966,7 @@
             },
             "code-point-at": {
               "version": "1.1.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "concat-map": {
               "version": "0.0.1",
@@ -9993,8 +9975,7 @@
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -10097,8 +10078,7 @@
             },
             "inherits": {
               "version": "2.0.3",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "ini": {
               "version": "1.3.5",
@@ -10108,7 +10088,6 @@
             "is-fullwidth-code-point": {
               "version": "1.0.0",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -10128,13 +10107,11 @@
             },
             "minimist": {
               "version": "0.0.8",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -10151,7 +10128,6 @@
             "mkdirp": {
               "version": "0.5.1",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -10224,8 +10200,7 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -10235,7 +10210,6 @@
             "once": {
               "version": "1.4.0",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -10311,8 +10285,7 @@
             },
             "safe-buffer": {
               "version": "5.1.2",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -10342,7 +10315,6 @@
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -10360,7 +10332,6 @@
             "strip-ansi": {
               "version": "3.0.1",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -10399,13 +10370,11 @@
             },
             "wrappy": {
               "version": "1.0.2",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "yallist": {
               "version": "3.0.3",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             }
           }
         }
@@ -17179,8 +17148,10 @@
         "gl-mat3": "1.0.0",
         "gl-mat4": "1.1.4",
         "gl-shader-errors": "1.0.3",
+        "js-yaml": "github:tangrams/js-yaml#1637976c6f593bed33ed088aedb6d01390a947c0",
         "jszip": "3.1.5",
-        "pbf": "3.1.0"
+        "pbf": "3.1.0",
+        "topojson-client": "github:tangrams/topojson-client#1068f4f2e03ddf8236499bbc896cec98d7a342b7"
       },
       "dependencies": {
         "esprima": {
@@ -17190,17 +17161,10 @@
         },
         "js-yaml": {
           "version": "github:tangrams/js-yaml#1637976c6f593bed33ed088aedb6d01390a947c0",
-          "from": "github:tangrams/js-yaml#1637976c6f593bed33ed088aedb6d01390a947c0",
+          "from": "github:tangrams/js-yaml#read-only",
           "requires": {
             "argparse": "^1.0.2",
             "esprima": "^2.6.0"
-          }
-        },
-        "topojson-client": {
-          "version": "github:tangrams/topojson-client#1068f4f2e03ddf8236499bbc896cec98d7a342b7",
-          "from": "github:tangrams/topojson-client#1068f4f2e03ddf8236499bbc896cec98d7a342b7",
-          "requires": {
-            "commander": "2"
           }
         }
       }
@@ -17480,6 +17444,13 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
       "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw=="
+    },
+    "topojson-client": {
+      "version": "github:tangrams/topojson-client#1068f4f2e03ddf8236499bbc896cec98d7a342b7",
+      "from": "github:tangrams/topojson-client#read-only",
+      "requires": {
+        "commander": "2"
+      }
     },
     "toposort": {
       "version": "2.0.2",

--- a/src/GjenbruksElement/Ekspander.js
+++ b/src/GjenbruksElement/Ekspander.js
@@ -9,7 +9,7 @@ const Ekspander = ({ visible, children, heading, heading2, icon }) => {
   if (!visible) return null;
 
   return (
-    <div
+    <button
       className="sidebar_element clickable_element"
       onClick={e => {
         e.stopPropagation();
@@ -32,7 +32,7 @@ const Ekspander = ({ visible, children, heading, heading2, icon }) => {
       </h3>
 
       {expanded === true && <div className="expander_content">{children}</div>}
-    </div>
+    </button>
   );
 };
 

--- a/src/HamburgerMeny/HamburgerMeny.js
+++ b/src/HamburgerMeny/HamburgerMeny.js
@@ -46,43 +46,54 @@ class HamburgerMeny extends Component {
                 </ListItemSecondaryAction>
               </ListItem>
               <Divider />
-              <div
-                tabIndex={0}
-                role="button"
-                onClick={context.onToggleHovedmeny}
-                onKeyDown={context.onToggleHovedmeny}
-              >
+
+              <div>
                 <Divider />
                 <ListSubheader>Hva vil du utforske?</ListSubheader>
 
-                <Utforsk parent={this} props={this} />
+                <Utforsk parent={this} props={this} context={context} />
 
                 <Divider />
                 <Menyelement
                   icon={<Info />}
                   primary="Informasjon"
-                  onClick={this.handleClickInfoTab}
+                  onClick={() => {
+                    this.handleClickInfoTab();
+                    context.onToggleHovedmeny();
+                  }}
                 />
                 <Divider />
                 <ListSubheader>Datagrunnlag</ListSubheader>
                 <Menyelement
                   icon={<CloudDownload />}
                   primary="Last ned data"
-                  onClick={this.handleClickLastNed}
+                  onClick={() => {
+                    this.handleClickLastNed();
+                    context.onToggleHovedmeny();
+                  }}
                 />
                 <Menyelement
-                  onClick={this.handleClickLastOpp}
+                  onClick={() => {
+                    this.handleClickLastOpp();
+                    context.onToggleHovedmeny();
+                  }}
                   icon={<CloudUpload />}
                   primary="Levere data"
                 />
 
                 <Menyelement
-                  onClick={this.handleClickDatakilde}
+                  onClick={() => {
+                    this.handleClickDatakilde();
+                    context.onToggleHovedmeny();
+                  }}
                   icon={<AssignmentInd />}
                   primary="Datakilder"
                 />
                 <Menyelement
-                  onClick={this.handleClickSource}
+                  onClick={() => {
+                    this.handleClickSource();
+                    context.onToggleHovedmeny();
+                  }}
                   icon={<GitHub />}
                   primary="Kildekode"
                 />
@@ -96,13 +107,19 @@ class HamburgerMeny extends Component {
                 <Divider />
                 <ListSubheader>Kontakt</ListSubheader>
                 <Menyelement
-                  onClick={this.handleClickBidra}
+                  onClick={() => {
+                    this.handleClickBidra();
+                    context.onToggleHovedmeny();
+                  }}
                   icon={<Comment />}
                   primary="Tilbakemeldinger"
                 />
 
                 <Menyelement
-                  onClick={this.handleClickLogo}
+                  onClick={() => {
+                    this.handleClickLogo();
+                    context.onToggleHovedmeny();
+                  }}
                   icon={<BildeAvatar url="Datakilde/Artsdatabanken" />}
                   primary="Artsdatabanken"
                 />

--- a/src/HamburgerMeny/Utforsk/Utforsk.js
+++ b/src/HamburgerMeny/Utforsk/Utforsk.js
@@ -11,13 +11,18 @@ const Utforsk = ({ parent, context }) => {
   if (!parent.history) {
     the_props = parent.props;
   }
+  function onToggleHovedmeny() {
+    if (context) {
+      context.onToggleHovedmeny();
+    }
+  }
 
   return (
     <>
       <Menyelement
         onClick={e => {
           the_props.history.push("/Natur_i_Norge/Natursystem");
-          context.onToggleHovedmeny();
+          onToggleHovedmeny();
         }}
         icon={<Panorama />}
         primary="Natursystem"
@@ -26,7 +31,7 @@ const Utforsk = ({ parent, context }) => {
       <Menyelement
         onClick={e => {
           the_props.history.push("/Natur_i_Norge/Landskap");
-          context.onToggleHovedmeny();
+          onToggleHovedmeny();
         }}
         icon={<Landscape />}
         primary="Landskap"
@@ -35,7 +40,7 @@ const Utforsk = ({ parent, context }) => {
       <Menyelement
         onClick={e => {
           the_props.history.push("/Fylke/");
-          context.onToggleHovedmeny();
+          onToggleHovedmeny();
         }}
         icon={<Layers />}
         primary="Fylke"
@@ -44,7 +49,7 @@ const Utforsk = ({ parent, context }) => {
       <Menyelement
         onClick={e => {
           the_props.history.push("/Naturvernområde/");
-          context.onToggleHovedmeny();
+          onToggleHovedmeny();
         }}
         icon={<Naturvern />}
         primary="Naturvernområde"
@@ -53,7 +58,7 @@ const Utforsk = ({ parent, context }) => {
       <Menyelement
         onClick={e => {
           the_props.history.push("/Biota/");
-          context.onToggleHovedmeny();
+          onToggleHovedmeny();
         }}
         icon={<Pets />}
         primary="Art"

--- a/src/HamburgerMeny/Utforsk/Utforsk.js
+++ b/src/HamburgerMeny/Utforsk/Utforsk.js
@@ -3,8 +3,8 @@ import React from "react";
 import { Panorama, Pets, Landscape, Layers } from "@material-ui/icons";
 import Naturvern from "HamburgerMeny/Naturvern";
 
-const Utforsk = ({ parent }) => {
-  /* 
+const Utforsk = ({ parent, context }) => {
+  /*
   Ridiculous check here to avoid props collapse when called from different places
   */
   let the_props = parent;
@@ -17,6 +17,7 @@ const Utforsk = ({ parent }) => {
       <Menyelement
         onClick={e => {
           the_props.history.push("/Natur_i_Norge/Natursystem");
+          context.onToggleHovedmeny();
         }}
         icon={<Panorama />}
         primary="Natursystem"
@@ -25,6 +26,7 @@ const Utforsk = ({ parent }) => {
       <Menyelement
         onClick={e => {
           the_props.history.push("/Natur_i_Norge/Landskap");
+          context.onToggleHovedmeny();
         }}
         icon={<Landscape />}
         primary="Landskap"
@@ -33,6 +35,7 @@ const Utforsk = ({ parent }) => {
       <Menyelement
         onClick={e => {
           the_props.history.push("/Fylke/");
+          context.onToggleHovedmeny();
         }}
         icon={<Layers />}
         primary="Fylke"
@@ -41,6 +44,7 @@ const Utforsk = ({ parent }) => {
       <Menyelement
         onClick={e => {
           the_props.history.push("/Naturvernområde/");
+          context.onToggleHovedmeny();
         }}
         icon={<Naturvern />}
         primary="Naturvernområde"
@@ -49,6 +53,7 @@ const Utforsk = ({ parent }) => {
       <Menyelement
         onClick={e => {
           the_props.history.push("/Biota/");
+          context.onToggleHovedmeny();
         }}
         icon={<Pets />}
         primary="Art"

--- a/src/TopBar/TopBar.js
+++ b/src/TopBar/TopBar.js
@@ -26,8 +26,16 @@ const TopBar = ({ onSelectResult, searchFor }) => {
       {context => (
         <div className="top_anchor">
           <div className="top_sidebar_background" />
-          <button className="invisible_icon_button hamburger">
-            <Hamburger onClick={context.onToggleHovedmeny} />
+          <button
+            className="invisible_icon_button hamburger"
+            onKeyDown={e => {
+              if (e.keyCode === 13) {
+                context.onToggleHovedmeny();
+              }
+            }}
+            onClick={context.onToggleHovedmeny}
+          >
+            <Hamburger />
           </button>
 
           <span className="header_text">


### PR DESCRIPTION
* Hamburgermenyen har fått fjernet et omliggende element som lukket ting når man tabbet i menyen
* Hamburgermenyknappen åpner nå hamburgeren ved tab, og klikkeventen er omplassert til knappen så alle events fyres på samme sted
* Hamburgermenyens interne objekter kunne alltid nås via tab-enter, men nå lukker den også dialogen etter at man har navigert seg til rett sted
* Ettersom noen av disse objektene gjenbrukes på forsiden, måtte det lages en fangst-funksjon når context ikke er tilgjengelig, for å unngå kræsj
* ekspander-tittelene ble omgjort til knapper, så de blir korrekt indexert og derav brukbare for brukere som benytter seg av tab + enter
* I kartlag, har noen objekt (fargemeny-knapp) blitt omgjort til knapper for å indexeres, og blitt angitt navnvariabler ettersom de kun inneholdte aksjonsobjekter, ikke navngitte lenker

Det er fremdeles en god del mer vi bør fikse på sikt, men dette var det som i utgangspunktet var mest knotete eller ikke-fungerende og stoppet all bruk av siden. Vi har ennå ikke ryddet opp i f.eks knapper på kartet, hvordan å bruke kartet i det heletatt, eller undermenyer som f.eks fargevelgere og miljøvariabler. Disse trenger vi litt planlegging før vi lager.
