### PR TITLE
Crash fordi "katalog"-nivå er borte

### DIFF
--- a/src/InformasjonsVisning/Katalog/KatalogInformasjon/KatalogInformasjon.js
+++ b/src/InformasjonsVisning/Katalog/KatalogInformasjon/KatalogInformasjon.js
@@ -1,10 +1,9 @@
 import React from "react";
-//import Detaljeringsgrad from "./Detaljeringsgrad";
 import KatalogInformasjonsBoks from "./KatalogInformasjonsBoks";
 import KatalogStatistikk from "InformasjonsVisning/Katalog/KatalogInformasjon/KatalogStatistikk/KatalogStatistikk";
 import språk from "Funksjoner/språk";
 
-const KatalogInformasjon = ({ meta, onUpdateLayerProp }) => {
+const KatalogInformasjon = ({ meta }) => {
   /*
   
   Contains information giving components.
@@ -21,7 +20,7 @@ const KatalogInformasjon = ({ meta, onUpdateLayerProp }) => {
     antallArter,
     stats
   } = meta;
-  const mor = overordnet[0] || { tittel: {} };
+  const mor = (overordnet.length > 0 && overordnet[0]) || { tittel: {} };
 
   return (
     <>

--- a/src/InformasjonsVisning/Meny/Meny/Navigeringsliste/Overordnet.js
+++ b/src/InformasjonsVisning/Meny/Meny/Navigeringsliste/Overordnet.js
@@ -4,12 +4,9 @@ import Bildeavatar from "GjenbruksElement/Bildeavatar";
 
 const Overordnet = ({ overordnet, onNavigate }) => {
   let underordnet = overordnet;
-  if (underordnet[underordnet.length - 1].url === "Katalog") {
-    underordnet = underordnet.slice(0, -1);
-  }
 
   if (
-    underordnet[underordnet.length - 1] &&
+    underordnet.length > 1 &&
     underordnet[underordnet.length - 1].url === "Natur_i_Norge"
   ) {
     underordnet = underordnet.slice(0, -1);


### PR DESCRIPTION
Fjerner forutsetning om at alle typer må ha overordnet.  Det skjer ikke lenger.